### PR TITLE
feat: detect major version change from Renovate

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,8 @@ const parseSemanticCommitMessage = (message: string): 'minor' | 'patch' | 'none'
 		return 'patch'
 	} else if (message.startsWith('feat')) {
 		return 'minor'
+	} else if (message.includes('(major)')) {
+		return 'minor'
 	}
 
 	return 'none'


### PR DESCRIPTION
Renovate will sometimes create PRs named as such:

`chore(deps): update XXX to vXYZ (major)`

For PRs with this naming convention, this action should detect the word major and bump the packages accordingly